### PR TITLE
Don't use NPM and PyPi proxies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_install:
     - export PATH=$HOME/.yarn/bin:$PATH
     # Install Twine so that we can publish Pip packages.
     - pip install --upgrade --user twine==1.9.1
-    # Ensure that we can access Pulumi's private NPM and PyPI orgs.
-    - if [ ! -z "${NPM_TOKEN}" ]; then echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc; fi
-    - mkdir -p ~/.config/pip && echo -e "[global]\nextra-index-url = https://${PULUMI_API_TOKEN}@pypi.pulumi.com/simple" >> ~/.config/pip/pip.conf
     # Install the AWS CLI so that we can publish the resulting release (if applicable) at the end.
     - pip install --upgrade --user awscli
     # Install kubectl


### PR DESCRIPTION
Since Pulumi left stealth mode, the packages are now available on NPM and PyPi proper.
/cc @praneetloke 